### PR TITLE
fix build.sh on OSX & update to java8u45

### DIFF
--- a/oracle-jdk/Dockerfile
+++ b/oracle-jdk/Dockerfile
@@ -11,7 +11,7 @@
 #
 # REQUIRED FILES TO BUILD THIS IMAGE
 # ----------------------------------
-# (1) jdk-8u25-linux-x64.rpm
+# (1) jdk-8u45-linux-x64.rpm
 #     Download from http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
 #
 # HOW TO BUILD THIS IMAGE
@@ -30,11 +30,11 @@ MAINTAINER Bruno Borges <bruno.borges@oracle.com>
 
 # Environment variables required for this build (do NOT change)
 # -------------------------------------------------------------
-ENV JAVA_RPM jdk-8u25-linux-x64.rpm
+ENV JAVA_RPM jdk-8u45-linux-x64.rpm
 ENV GLASSFISH_PKG http://dlc-cdn.sun.com/glassfish/4.1/release/glassfish-4.1.zip
 ENV PKG_FILE_NAME glassfish-4.1.zip
 
-# Install and configure Oracle JDK 8u25
+# Install and configure Oracle JDK 8u45
 # -------------------------------------
 ADD $JAVA_RPM /root/
 RUN rpm -i /root/$JAVA_RPM && rm /root/$JAVA_RPM

--- a/oracle-jdk/build.sh
+++ b/oracle-jdk/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 IMAGE_NAME=glassfish:4.1
-JAVA_VERSION="8u25"
+JAVA_VERSION="8u45"
 JAVA_PKG="jdk-${JAVA_VERSION}-linux-x64.rpm"
-JAVA_PKG_MD5="6a8897b5d92e5850ef3458aa89a5e9d7"
+JAVA_PKG_MD5="50ae04f69743921dd6082dfe978672ad"
 
 # Validate Java Package
 echo "====================="

--- a/oracle-jdk/build.sh
+++ b/oracle-jdk/build.sh
@@ -15,8 +15,15 @@ then
   exit
 fi
 
-MD5="$JAVA_PKG_MD5  $JAVA_PKG"
-MD5_CHECK="`md5sum $JAVA_PKG`"
+if [ `uname` != "Darwin" ]
+then
+  MD5="$JAVA_PKG_MD5  $JAVA_PKG"
+  MD5_CHECK="`md5sum $JAVA_PKG`"
+else
+  MD5="$JAVA_PKG_MD5"
+  MD5_CHECK="`md5 -q $JAVA_PKG`"
+fi
+
 
 if [ "$MD5" != "$MD5_CHECK" ]
 then


### PR DESCRIPTION
- Modify the build.sh script to detect building on OSX and use altenate md5 binary.
- Update from java8u25 to java8u45
